### PR TITLE
Removes field_checklist from non-dummy fields

### DIFF
--- a/imagine/__version__.py
+++ b/imagine/__version__.py
@@ -8,4 +8,4 @@ Stores the different versions of the *IMAGINE* package.
 
 # %% VERSIONS
 # Default/Latest/Current version
-__version__ = '2.0.0a2'
+__version__ = '2.0.0a3'

--- a/imagine/fields/base_fields.py
+++ b/imagine/fields/base_fields.py
@@ -118,7 +118,7 @@ class DummyField(Field):
     # Class attributes
     TYPE = 'dummy'
     UNITS = None
-    PARAMETERS_LIST = None
+    PARAMETER_NAMES = None
 
     def __init__(self, *args, **kwargs):
         kwargs['grid'] = None
@@ -133,9 +133,9 @@ class DummyField(Field):
         return(None)
 
     @property
-    def parameters_list(self):
+    def parameter_names(self):
         """Parameters of the field"""
-        return [k for k in self.field_checklist]
+        return list(self.field_checklist)
 
     @property
     def field_checklist(self):

--- a/imagine/fields/base_fields.py
+++ b/imagine/fields/base_fields.py
@@ -16,11 +16,15 @@ See also :doc:`IMAGINE Components <components>` section of the docs.
 """
 
 # %% IMPORTS
+# Built-in imports
+import abc
+
 # Package imports
 import astropy.units as u
 
 # IMAGINE imports
 from imagine.fields import Field
+from imagine.tools import req_attr
 
 # All declaration
 __all__ = ['MagneticField', 'ThermalElectronDensityField', 'DummyField']
@@ -109,7 +113,7 @@ class CosmicRayElectronDensityField(Field):
         raise NotImplementedError
 
 
-class DummyField(Field):
+class DummyField(Field, metaclass=abc.ABCMeta):
     """
     Base class for a dummy Field used for sending parameters and settings to
     specific Simulators rather than computing and storing a physical field.
@@ -138,16 +142,18 @@ class DummyField(Field):
         return list(self.field_checklist)
 
     @property
+    @req_attr
     def field_checklist(self):
         """Parameters of the dummy field"""
-        return getattr(self, 'FIELD_CHECKLIST', {})
+        return self.FIELD_CHECKLIST
 
     @property
+    @req_attr
     def simulator_controllist(self):
         """
         Dictionary containing fixed Simulator settings
         """
-        return getattr(self, 'SIMULATOR_CONTROLLIST', {})
+        return self.SIMULATOR_CONTROLLIST
 
     def compute_field(self, *args, **kwargs):
         pass

--- a/imagine/fields/base_fields.py
+++ b/imagine/fields/base_fields.py
@@ -118,6 +118,7 @@ class DummyField(Field):
     # Class attributes
     TYPE = 'dummy'
     UNITS = None
+    PARAMETERS_LIST = None
 
     def __init__(self, *args, **kwargs):
         kwargs['grid'] = None
@@ -132,15 +133,21 @@ class DummyField(Field):
         return(None)
 
     @property
+    def parameters_list(self):
+        """Parameters of the field"""
+        return [k for k in self.field_checklist]
+
+    @property
     def field_checklist(self):
-        return({})
+        """Parameters of the dummy field"""
+        return getattr(self, 'FIELD_CHECKLIST', {})
 
     @property
     def simulator_controllist(self):
         """
         Dictionary containing fixed Simulator settings
         """
-        return({})
+        return getattr(self, 'SIMULATOR_CONTROLLIST', {})
 
     def compute_field(self, *args, **kwargs):
         pass

--- a/imagine/fields/basic_fields.py
+++ b/imagine/fields/basic_fields.py
@@ -24,7 +24,7 @@ class ConstantMagneticField(MagneticField):
 
     # Class attributes
     NAME = 'constant_B'
-    PARAMETERS_LIST = ['Bx', 'By', 'Bz']
+    PARAMETER_NAMES = ['Bx', 'By', 'Bz']
 
     def compute_field(self, seed):
         # Creates an empty array to store the result
@@ -50,7 +50,7 @@ class ConstantThermalElectrons(ThermalElectronDensityField):
 
     # Class attributes
     NAME = 'constant_TE'
-    PARAMETERS_LIST = ['ne']
+    PARAMETER_NAMES = ['ne']
 
     def compute_field(self, seed):
         return np.ones(self.data_shape)*self.parameters['ne']
@@ -74,7 +74,7 @@ class ExponentialThermalElectrons(ThermalElectronDensityField):
 
     # Class attributes
     NAME = 'exponential_disc_thermal_electrons'
-    PARAMETERS_LIST = ['central_density',
+    PARAMETER_NAMES = ['central_density',
                        'scale_radius',
                        'scale_height']
 
@@ -106,7 +106,7 @@ class RandomThermalElectrons(ThermalElectronDensityField):
     # Class attributes
     NAME = 'random_thermal_electrons'
     STOCHASTIC_FIELD = True
-    PARAMETERS_LIST = ['mean', 'std', 'min_ne']
+    PARAMETER_NAMES = ['mean', 'std', 'min_ne']
 
     def compute_field(self, seed):
         # Converts dimensional parameters into numerical values

--- a/imagine/fields/basic_fields.py
+++ b/imagine/fields/basic_fields.py
@@ -24,10 +24,7 @@ class ConstantMagneticField(MagneticField):
 
     # Class attributes
     NAME = 'constant_B'
-
-    @property
-    def field_checklist(self):
-        return {'Bx': None, 'By': None, 'Bz': None}
+    PARAMETERS_LIST = ['Bx', 'By', 'Bz']
 
     def compute_field(self, seed):
         # Creates an empty array to store the result
@@ -45,7 +42,7 @@ class ConstantMagneticField(MagneticField):
 
 class ConstantThermalElectrons(ThermalElectronDensityField):
     """
-    Constant magnetic field
+    Constant thermal electron density field
 
     The field parameters are:
     'ne', the number density of thermal electrons
@@ -53,10 +50,7 @@ class ConstantThermalElectrons(ThermalElectronDensityField):
 
     # Class attributes
     NAME = 'constant_TE'
-
-    @property
-    def field_checklist(self):
-        return {'ne': None}
+    PARAMETERS_LIST = ['ne']
 
     def compute_field(self, seed):
         return np.ones(self.data_shape)*self.parameters['ne']
@@ -80,12 +74,9 @@ class ExponentialThermalElectrons(ThermalElectronDensityField):
 
     # Class attributes
     NAME = 'exponential_disc_thermal_electrons'
-
-    @property
-    def field_checklist(self):
-        return {'central_density' : None,
-                'scale_radius' : None,
-                'scale_height' : None}
+    PARAMETERS_LIST = ['central_density',
+                       'scale_radius',
+                       'scale_height']
 
     def compute_field(self, seed):
         R = self.grid.r_cylindrical
@@ -115,10 +106,7 @@ class RandomThermalElectrons(ThermalElectronDensityField):
     # Class attributes
     NAME = 'random_thermal_electrons'
     STOCHASTIC_FIELD = True
-
-    @property
-    def field_checklist(self):
-        return {'mean': None, 'std': None, 'min_ne': None}
+    PARAMETERS_LIST = ['mean', 'std', 'min_ne']
 
     def compute_field(self, seed):
         # Converts dimensional parameters into numerical values
@@ -134,6 +122,6 @@ class RandomThermalElectrons(ThermalElectronDensityField):
 
         # Applies minimum density, if present
         if np.isfinite(minimum_density):
-            result[result<minimum_density] = minimum_density
+            result[result < minimum_density] = minimum_density
 
-        return result << self.units # Restores units
+        return result << self.units  # Restores units

--- a/imagine/fields/field.py
+++ b/imagine/fields/field.py
@@ -69,6 +69,12 @@ class Field(BaseClass, metaclass=abc.ABCMeta):
         return(self.TYPE)
 
     @property
+    @req_attr
+    def parameters_list(self):
+        """Parameters of the field"""
+        return self.PARAMETERS_LIST
+
+    @property
     def dependencies_list(self):
         """Dependencies on other fields"""
         return(getattr(self, 'DEPENDENCIES_LIST', []))
@@ -146,7 +152,7 @@ class Field(BaseClass, metaclass=abc.ABCMeta):
             :py:data:`data_description` in units :py:data:`field_units`.
         """
         if self.stochastic_field:
-            assert i_realization<self.ensemble_size
+            assert i_realization < self.ensemble_size
             # Checks and updates dependencies
             self._update_dependencies(dependencies)
             # Computes stochastic field
@@ -184,11 +190,6 @@ class Field(BaseClass, metaclass=abc.ABCMeta):
             print('Description:', self.data_description)
             raise
 
-    @abc.abstractproperty
-    def field_checklist(self):
-        """Dictionary with all parameter names as keys"""
-        raise NotImplementedError
-
     @property
     def ensemble_seeds(self):
         return self._ensemble_seeds
@@ -213,6 +214,6 @@ class Field(BaseClass, metaclass=abc.ABCMeta):
     @parameters.setter
     def parameters(self, parameters):
         for k in parameters:
-            assert (k in self.field_checklist)
+            assert (k in self.parameters_list)
         self._parameters.update(parameters)
         log.debug('update full-set parameters %s' % (parameters))

--- a/imagine/fields/field.py
+++ b/imagine/fields/field.py
@@ -70,9 +70,9 @@ class Field(BaseClass, metaclass=abc.ABCMeta):
 
     @property
     @req_attr
-    def parameters_list(self):
+    def parameter_names(self):
         """Parameters of the field"""
-        return self.PARAMETERS_LIST
+        return self.PARAMETER_NAMES
 
     @property
     def dependencies_list(self):
@@ -214,6 +214,6 @@ class Field(BaseClass, metaclass=abc.ABCMeta):
     @parameters.setter
     def parameters(self, parameters):
         for k in parameters:
-            assert (k in self.parameters_list)
+            assert (k in self.parameter_names)
         self._parameters.update(parameters)
         log.debug('update full-set parameters %s' % (parameters))

--- a/imagine/fields/hamx/breg_lsa.py
+++ b/imagine/fields/hamx/breg_lsa.py
@@ -17,26 +17,18 @@ class BregLSA(DummyField):
 
     # Class attributes
     NAME = 'breg_lsa'
-
-    @property
-    def field_checklist(self):
-        """
-        Hammurabi XML locations of physical parameters
-        """
-        checklist = {'b0': (['magneticfield', 'regular', 'lsa', 'b0'], 'value'),
-                     'psi0': (['magneticfield', 'regular', 'lsa', 'psi0'], 'value'),
-                     'psi1': (['magneticfield', 'regular', 'lsa', 'psi1'], 'value'),
-                     'chi0': (['magneticfield', 'regular', 'lsa', 'chi0'], 'value')}
-        return checklist
-
-    @property
-    def simulator_controllist(self):
-        """
-        Hammurabi XML locations of logical parameters
-        """
-        controllist = {'cue': (['magneticfield', 'regular'], {'cue': '1'}),
-                       'type': (['magneticfield', 'regular'], {'type': 'lsa'})}
-        return controllist
+    FIELD_CHECKLIST = {'b0': (['magneticfield', 'regular', 'lsa', 'b0'],
+                              'value'),
+                       'psi0': (['magneticfield', 'regular', 'lsa', 'psi0'],
+                                'value'),
+                       'psi1': (['magneticfield', 'regular', 'lsa', 'psi1'],
+                                'value'),
+                       'chi0': (['magneticfield', 'regular', 'lsa', 'chi0'],
+                                'value')}
+    SIMULATOR_CONTROLLIST = {'cue': (['magneticfield', 'regular'],
+                                     {'cue': '1'}),
+                             'type': (['magneticfield', 'regular'],
+                                      {'type': 'lsa'})}
 
 
 class BregLSAFactory(FieldFactory):

--- a/imagine/fields/hamx/brnd_es.py
+++ b/imagine/fields/hamx/brnd_es.py
@@ -17,6 +17,8 @@ class BrndES(DummyField):
 
     # Class attributes
     NAME = 'breg_wmap'
+    SIMULATOR_CONTROLLIST = None  # Unused, see simulator_controllist property
+    FIELD_CHECKLIST = None  # Unused, see field_checklist property
 
     def __init__(self, *args, grid_nx=None, grid_ny=None, grid_nz=None,
                  **kwargs):

--- a/imagine/fields/hamx/cre_analytic.py
+++ b/imagine/fields/hamx/cre_analytic.py
@@ -16,28 +16,15 @@ class CREAna(DummyField):
     """
     NAME = 'cre_ana'
 
-    @property
-    def field_checklist(self):
-        """
-        Hammurabi XML locations of physical parameters
-        """
-        checklist = {'alpha': (['cre', 'analytic', 'alpha'], 'value'),
-                     'beta': (['cre', 'analytic', 'beta'], 'value'),
-                     'theta': (['cre', 'analytic', 'theta'], 'value'),
-                     'r0': (['cre', 'analytic', 'r0'], 'value'),
-                     'z0': (['cre', 'analytic', 'z0'], 'value'),
-                     'E0': (['cre', 'analytic', 'E0'], 'value'),
-                     'j0': (['cre', 'analytic', 'j0'], 'value')}
-        return checklist
-
-    @property
-    def simulator_controllist(self):
-        """
-        Hammurabi XML locations of logical parameters
-        """
-        controllist = {'cue': (['cre'], {'cue': '1'}),
-                       'type': (['cre'], {'type': 'analytic'})}
-        return controllist
+    FIELD_CHECKLIST = {'alpha': (['cre', 'analytic', 'alpha'], 'value'),
+                       'beta': (['cre', 'analytic', 'beta'], 'value'),
+                       'theta': (['cre', 'analytic', 'theta'], 'value'),
+                       'r0': (['cre', 'analytic', 'r0'], 'value'),
+                       'z0': (['cre', 'analytic', 'z0'], 'value'),
+                       'E0': (['cre', 'analytic', 'E0'], 'value'),
+                       'j0': (['cre', 'analytic', 'j0'], 'value')}
+    SIMULATOR_CONTROLLIST = {'cue': (['cre'], {'cue': '1'}),
+                             'type': (['cre'], {'type': 'analytic'})}
 
 
 class CREAnaFactory(FieldFactory):

--- a/imagine/fields/hamx/tereg_ymw16.py
+++ b/imagine/fields/hamx/tereg_ymw16.py
@@ -12,26 +12,13 @@ class TEregYMW16(DummyField):
     This dummy field instructs the :py:class:`Hammurabi <imagine.simulators.hammurabi.Hammurabi>`
     simulator class to use the HammurabiX's thermal electron density model YMW16
     """
-
     # Class attributes
     NAME = 'tereg_ymw16'
-
-    @property
-    def field_checklist(self):
-        """
-        Hammurabi XML locations of physical parameters
-        """
-        checklist = dict()
-        return checklist
-
-    @property
-    def simulator_controllist(self):
-        """
-        Hammurabi XML locations of logical parameters
-        """
-        controllist = {'cue': (['thermalelectron', 'regular'], {'cue': '1'}),
-                       'type': (['thermalelectron', 'regular'], {'type': 'ymw16'})}
-        return controllist
+    FIELD_CHECKLIST = {}
+    SIMULATOR_CONTROLLIST = {'cue': (['thermalelectron', 'regular'],
+                                     {'cue': '1'}),
+                             'type': (['thermalelectron', 'regular'],
+                                      {'type': 'ymw16'})}
 
 
 class TEregYMW16Factory(FieldFactory):
@@ -39,7 +26,6 @@ class TEregYMW16Factory(FieldFactory):
     Field factory that produces the dummy field :py:class:`TEregYMW16`
     (see its docs for details).
     """
-
     # Class attributes
     FIELD_CLASS = TEregYMW16
     DEFAULT_PARAMETERS = {}

--- a/imagine/fields/test_field.py
+++ b/imagine/fields/test_field.py
@@ -31,11 +31,8 @@ class CosThermalElectronDensity(ThermalElectronDensityField):
 
     # Class attributes
     NAME = 'cos_therm_electrons'
-
-    @property
-    def field_checklist(self):
-        return {'n0' : None, 'a' : None, 'alpha' : None,
-                'b' : None, 'beta' : None, 'c' : None, 'gamma' : None}
+    PARAMETERS_LIST = {'n0' : None, 'a' : None, 'alpha' : None,
+                      'b' : None, 'beta' : None, 'c' : None, 'gamma' : None}
 
     def compute_field(self, seed):
         x = self.grid.x
@@ -84,10 +81,7 @@ class NaiveGaussianMagneticField(MagneticField):
     # Class attributes
     NAME = 'naive_gaussian_magnetic_field'
     STOCHASTIC_FIELD = True
-
-    @property
-    def field_checklist(self):
-        return {'a0' : None, 'b0' : None}
+    PARAMETERS_LIST = {'a0' : None, 'b0' : None}
 
     def compute_field(self, seed):
 

--- a/imagine/fields/test_field.py
+++ b/imagine/fields/test_field.py
@@ -31,8 +31,7 @@ class CosThermalElectronDensity(ThermalElectronDensityField):
 
     # Class attributes
     NAME = 'cos_therm_electrons'
-    PARAMETERS_LIST = {'n0' : None, 'a' : None, 'alpha' : None,
-                      'b' : None, 'beta' : None, 'c' : None, 'gamma' : None}
+    PARAMETER_NAMES = ['n0', 'a', 'alpha', 'b', 'beta', 'c', 'gamma']
 
     def compute_field(self, seed):
         x = self.grid.x
@@ -81,7 +80,7 @@ class NaiveGaussianMagneticField(MagneticField):
     # Class attributes
     NAME = 'naive_gaussian_magnetic_field'
     STOCHASTIC_FIELD = True
-    PARAMETERS_LIST = {'a0' : None, 'b0' : None}
+    PARAMETER_NAMES = ['a0', 'b0']
 
     def compute_field(self, seed):
 

--- a/imagine/simulators/hammurabi.py
+++ b/imagine/simulators/hammurabi.py
@@ -141,10 +141,10 @@ class Hammurabi(Simulator):
         """
         # This replaces the old `update_fields` method
         log.debug('@ hammurabi::_update_hammurabi_parameters')
-        if 'dummy' not in self.field_checklist:
+        if 'dummy' not in self.fields:
             return
 
-        checklist = self.field_checklist['dummy']
+        checklist = self.field_checklist
         parameters = self.fields['dummy']
 
         # hammurabiX does not support int64 seeds

--- a/imagine/simulators/simulator.py
+++ b/imagine/simulators/simulator.py
@@ -52,6 +52,7 @@ class Simulator(BaseClass, metaclass=abc.ABCMeta):
         self.grids = None
         self.fields = None
         self.field_checklist = {}
+        self.field_parameters = {}
         self.controllist = {}
         self.observables = []
         self.output_coords = {}
@@ -163,8 +164,11 @@ class Simulator(BaseClass, metaclass=abc.ABCMeta):
                 if field.type not in self.fields:
                     # Stores the data
                     self.fields[field.type] = field.get_data(i, dependencies)
-                    # Stores the checklist dictionary
-                    self.field_checklist[field.type] = field.field_checklist
+                    # Stores the parameters list
+                    self.field_parameters[field.type] = field.parameters_list
+                    # Stores the checklist (for dummies only)
+                    if field.type == 'dummy':
+                        self.field_checklist = field.field_checklist.copy()
 
                 elif field.type != 'dummy':
                     # If multiple fields of the same type are present, sums them up
@@ -179,8 +183,7 @@ class Simulator(BaseClass, metaclass=abc.ABCMeta):
                     self.fields[field.type].update(field.get_data(i, dependencies))
 
                     # The checklists are also combined
-                    self.field_checklist[field.type] = self.field_checklist[field.type].copy()
-                    self.field_checklist[field.type].update(field.field_checklist)
+                    self.field_checklist.update(field.field_checklist)
 
                 if field.type == 'dummy':
                     self.controllist[field.name] = field.simulator_controllist

--- a/imagine/simulators/simulator.py
+++ b/imagine/simulators/simulator.py
@@ -165,7 +165,7 @@ class Simulator(BaseClass, metaclass=abc.ABCMeta):
                     # Stores the data
                     self.fields[field.type] = field.get_data(i, dependencies)
                     # Stores the parameters list
-                    self.field_parameters[field.type] = field.parameters_list
+                    self.field_parameters[field.type] = field.parameter_names
                     # Stores the checklist (for dummies only)
                     if field.type == 'dummy':
                         self.field_checklist = field.field_checklist.copy()

--- a/imagine/templates/magnetic_field_template.py
+++ b/imagine/templates/magnetic_field_template.py
@@ -15,8 +15,8 @@ class MagneticFieldTemplate(MagneticField):
     STOCHASTIC_FIELD = True
     # If there are any dependencies, they should be included in this list
     DEPENDENCIES_LIST = []
-    # List of all parameters of the field
-    PARAMETERS_LIST = {'Parameter_A': None, 'Parameter_B': None}
+    # List of all parameters for the field
+    PARAMETER_NAMES = ['Parameter_A', 'Parameter_B']
 
     def compute_field(self, seed):
         # If this is an stochastic field, the integer `seed `must be

--- a/imagine/templates/magnetic_field_template.py
+++ b/imagine/templates/magnetic_field_template.py
@@ -15,12 +15,8 @@ class MagneticFieldTemplate(MagneticField):
     STOCHASTIC_FIELD = True
     # If there are any dependencies, they should be included in this list
     DEPENDENCIES_LIST = []
-
-    @property
-    def field_checklist(self):
-        # This property returns a dictionary with all the
-        # available parameters as keys
-        return {'Parameter_A': None, 'Parameter_B': None}
+    # List of all parameters of the field
+    PARAMETERS_LIST = {'Parameter_A': None, 'Parameter_B': None}
 
     def compute_field(self, seed):
         # If this is an stochastic field, the integer `seed `must be

--- a/imagine/templates/simulator_template.py
+++ b/imagine/templates/simulator_template.py
@@ -55,10 +55,9 @@ class SimulatorTemplate(Simulator):
         # If a dummy field is being used, instead of an actual realisation,
         # the parameters can be accessed from self.fields['dummy']
         my_dummy_field_parameters = self.fields['dummy']
-        # Checklists can be used to send specific information to simulators
-        # about specific parameters. Usually, to keep the modularity, this is
-        # only done only for dummy fields
-        checklist_params = self.field_checklist['dummy']
+        # Checklists allow _dummy fields_ to send specific information to
+        # simulators about specific parameters
+        checklist_params = self.field_checklist
         # Controllists in dummy fields contain a dict of simulator settings
         simulator_settings = self.controllist
 

--- a/imagine/templates/thermal_electrons_template.py
+++ b/imagine/templates/thermal_electrons_template.py
@@ -13,12 +13,7 @@ class ThermalElectronsDensityTemplate(ThermalElectronDensityField):
     STOCHASTIC_FIELD = True
     # If there are any dependencies, they should be included in this list
     DEPENDENCIES_LIST = []
-
-    @property
-    def field_checklist(self):
-        # This property returns a dictionary with all the
-        # available parameters as keys
-        return {'Parameter_A': None, 'Parameter_B': None}
+    PARAMETERS_LIST = ['Parameter_A', 'Parameter_B']
 
     def compute_field(self, seed):
         # If this is an stochastic field, the integer `seed `must be

--- a/imagine/templates/thermal_electrons_template.py
+++ b/imagine/templates/thermal_electrons_template.py
@@ -13,7 +13,8 @@ class ThermalElectronsDensityTemplate(ThermalElectronDensityField):
     STOCHASTIC_FIELD = True
     # If there are any dependencies, they should be included in this list
     DEPENDENCIES_LIST = []
-    PARAMETERS_LIST = ['Parameter_A', 'Parameter_B']
+    # List of all parameters for the field
+    PARAMETER_NAMES = ['Parameter_A', 'Parameter_B']
 
     def compute_field(self, seed):
         # If this is an stochastic field, the integer `seed `must be

--- a/imagine/tests/mocks_for_templates.py
+++ b/imagine/tests/mocks_for_templates.py
@@ -74,6 +74,7 @@ class MY_PACKAGE_MY_FIELD_CLASS(DummyField):
     NAME = 'name_of_the_dummy_field'
     FIELD_CHECKLIST =  {'Parameter_A': 'parameter_A_settings',
                         'Parameter_B': None}
+    SIMULATOR_CONTROLLIST = {}
 
 
 MY_PACKAGE = type(sys)('MY_PACKAGE')

--- a/imagine/tests/mocks_for_templates.py
+++ b/imagine/tests/mocks_for_templates.py
@@ -60,12 +60,8 @@ class MockDummy(DummyField):
     Used in the test_simulator_template function
     """
     NAME = 'mock'
-    @property
-    def field_checklist(self):
-        return {'value': 101010, 'units': None}
-    @property
-    def simulator_controllist(self):
-        return {'start_value': 17}
+    FIELD_CHECKLIST = {'value': 101010, 'units': None}
+    SIMULATOR_CONTROLLIST = {'start_value': 17}
 
 
 
@@ -76,11 +72,9 @@ class MY_PACKAGE_MY_FIELD_CLASS(DummyField):
 
     # Class attributes
     NAME = 'name_of_the_dummy_field'
+    FIELD_CHECKLIST =  {'Parameter_A': 'parameter_A_settings',
+                        'Parameter_B': None}
 
-    @property
-    def field_checklist(self):
-        return {'Parameter_A': 'parameter_A_settings',
-                'Parameter_B': None}
 
 MY_PACKAGE = type(sys)('MY_PACKAGE')
 MY_PACKAGE.MY_FIELD_CLASS = MY_PACKAGE_MY_FIELD_CLASS

--- a/imagine/tests/test_dependencies.py
+++ b/imagine/tests/test_dependencies.py
@@ -28,7 +28,7 @@ class A(ThermalElectronDensityField):
     """Independent electron density"""
 
     NAME = 'A'
-    PARAMETERS_LIST = []
+    PARAMETER_NAMES = []
 
     def compute_field(self, seed):
         return np.ones(self.data_shape)*self.units
@@ -38,7 +38,7 @@ class B(ThermalElectronDensityField):
     """Independent electron density"""
 
     NAME = 'B'
-    PARAMETERS_LIST = []
+    PARAMETER_NAMES = []
 
     def compute_field(self, seed):
         self.secret = 9  # Example of shared information
@@ -60,7 +60,7 @@ class D(MagneticField):
     """
 
     NAME = 'D'
-    PARAMETERS_LIST = []
+    PARAMETER_NAMES = []
     DEPENDENCIES_LIST = [B, C]
 
     def compute_field(self, seed):
@@ -77,7 +77,7 @@ class E(MagneticField):
     """
 
     NAME = 'E'
-    PARAMETERS_LIST = []
+    PARAMETER_NAMES = []
     DEPENDENCIES_LIST = ['thermal_electron_density']
 
     def compute_field(self, seed):
@@ -93,7 +93,7 @@ class F(MagneticField):
 
     NAME = 'F'
     DEPENDENCIES_LIST = [B, C]
-    PARAMETERS_LIST = []
+    PARAMETER_NAMES = []
 
     def compute_field(self, seed):
         return np.ones(self.data_shape)*0.1*u.microgauss

--- a/imagine/tests/test_dependencies.py
+++ b/imagine/tests/test_dependencies.py
@@ -28,10 +28,7 @@ class A(ThermalElectronDensityField):
     """Independent electron density"""
 
     NAME = 'A'
-
-    @property
-    def field_checklist(self):
-        return({})
+    PARAMETERS_LIST = []
 
     def compute_field(self, seed):
         return np.ones(self.data_shape)*self.units
@@ -41,13 +38,10 @@ class B(ThermalElectronDensityField):
     """Independent electron density"""
 
     NAME = 'B'
-
-    @property
-    def field_checklist(self):
-        return({})
+    PARAMETERS_LIST = []
 
     def compute_field(self, seed):
-        self.secret = 9 # Example of shared information
+        self.secret = 9  # Example of shared information
         return np.ones(self.data_shape)*self.units/2.
 
 
@@ -66,11 +60,8 @@ class D(MagneticField):
     """
 
     NAME = 'D'
+    PARAMETERS_LIST = []
     DEPENDENCIES_LIST = [B, C]
-
-    @property
-    def field_checklist(self):
-        return({})
 
     def compute_field(self, seed):
         result = np.ones(self.data_shape)*self.units
@@ -86,17 +77,14 @@ class E(MagneticField):
     """
 
     NAME = 'E'
+    PARAMETERS_LIST = []
     DEPENDENCIES_LIST = ['thermal_electron_density']
-
-    @property
-    def field_checklist(self):
-        return({})
 
     def compute_field(self, seed):
         te_density = self.dependencies['thermal_electron_density']
         B = np.empty(self.data_shape)
         for i in range(3):
-            B[...,i] = te_density.value
+            B[..., i] = te_density.value
         return B*u.microgauss
 
 
@@ -104,23 +92,21 @@ class F(MagneticField):
     """Independent magnetic field"""
 
     NAME = 'F'
-
-    @property
-    def field_checklist(self):
-        return({})
+    DEPENDENCIES_LIST = [B, C]
+    PARAMETERS_LIST = []
 
     def compute_field(self, seed):
         return np.ones(self.data_shape)*0.1*u.microgauss
 
 
 # We initalize a common grid for all the tests
-grid = UniformGrid([[0,1]]*3*u.kpc,resolution=[1]*3)
+grid = UniformGrid([[0, 1]]*3*u.kpc, resolution=[1]*3)
 
 
 class DummySimulator(Simulator):
     # Class attributes
     SIMULATED_QUANTITIES = ['nothing']
-    REQUIRED_FIELD_TYPES = ['dummy','magnetic_field',
+    REQUIRED_FIELD_TYPES = ['dummy', 'magnetic_field',
                             'thermal_electron_density']
     ALLOWED_GRID_TYPES = ['cartesian']
 
@@ -150,8 +136,8 @@ def test_Field_dependency():
 
     # Checks whether dependencies on classes are working
     b.get_data()  # Needs to evaluate these once
-    c.get_data(dependencies={B:b}) # Needs to evaluate these once
-    result = d.get_data(dependencies={B:b, C:c})
+    c.get_data(dependencies={B: b})  # Needs to evaluate these once
+    result = d.get_data(dependencies={B: b, C: c})
     assert np.all(result == [[[9]*3]]*u.microgauss)
 
     # Checks whether dependencies on types are working
@@ -161,13 +147,13 @@ def test_Field_dependency():
 
 
 def test_Simulator_dependency_resolution():
-    dat = TabularDataset({'x':[0],'lat':0,'lon':0,'err':0.1},
-                          name='nothing',
-                          units=u.rad,
-                          data_column='x',
-                          error_column='err',
-                          lat_column='lat',
-                          lon_column='lon')
+    dat = TabularDataset({'x': [0], 'lat': 0, 'lon': 0, 'err': 0.1},
+                         name='nothing',
+                         units=u.rad,
+                         data_column='x',
+                         error_column='err',
+                         lat_column='lat',
+                         lon_column='lon')
     mea = Measurements()
     mea.append(dataset=dat)
 

--- a/imagine/tests/test_dependencies.py
+++ b/imagine/tests/test_dependencies.py
@@ -49,6 +49,8 @@ class C(DummyField):
     """Dummy field dependent on B"""
 
     NAME = 'C'
+    FIELD_CHECKLIST = {}
+    SIMULATOR_CONTROLLIST = {}
     DEPENDENCIES_LIST = [B]
 
 

--- a/tutorials/tutorial_fields.ipynb
+++ b/tutorials/tutorial_fields.ipynb
@@ -182,12 +182,7 @@
     "    \"\"\"Example: thermal electron density of an (double) exponential disc\"\"\"\n",
     "    \n",
     "    NAME = 'exponential_disc_thermal_electrons'\n",
-    "    \n",
-    "    @property\n",
-    "    def field_checklist(self):\n",
-    "        return {'central_density' : None, \n",
-    "                'scale_radius' : None,\n",
-    "                'scale_height' : None}\n",
+    "    PARAMETERS_LIST = ['central_density', 'scale_radius', 'scale_height']\n",
     "    \n",
     "    def compute_field(self, seed):\n",
     "        R = self.grid.r_cylindrical\n",
@@ -205,11 +200,9 @@
    "source": [
     "With these few lines we have created our IMAGINE-compatible™ thermal electron density field class!\n",
     "\n",
-    "The class-attribute `field_name` allows one to keep track of which model we have used to generate our field. \n",
+    "The class-attribute `NAME` allows one to keep track of which model we have used to generate our field. \n",
     "\n",
-    "The `stochastic field` class-attribute tells whether the field is deterministic (i.e. the output depends only on the parameter values) or stochastic (i.e. the ouput is a random realisation which depends on a particular random seed). In this particular case we construct a deterministic field.\n",
-    "\n",
-    "The `field_checklist` property is a dictionary whose keys are required parameters for this particular kind of field. The values in the dictionary can be used for specialized checking by some simulators (but can be left as `None` in the general case).\n",
+    "The `PARAMETERS_LIST` attribute must contain all the required parameters for this particular kind of field.\n",
     "\n",
     "The function `compute_field` is what actually computes the density field. Note that it can access an associated grid object, which is stored in the `grid` attribute, and a dictionary of parameters, stored in the `parameters` attribute. The `compute_field` method takes a `seed` argument, which can is only used for stochastic fields (see later).\n",
     "\n",
@@ -332,10 +325,7 @@
     "class ConstantMagneticField(MagneticField):\n",
     "    \"\"\"Example: constant magnetic field\"\"\"\n",
     "    NAME = 'constantB'\n",
-    "    \n",
-    "    @property\n",
-    "    def field_checklist(self):\n",
-    "        return {'Bx': None, 'By': None, 'Bz': None}\n",
+    "    PARAMETERS_LIST = ['Bx', 'By', 'Bz']\n",
     "    \n",
     "    def compute_field(self, seed):\n",
     "        # Creates an empty array to store the result\n",
@@ -465,11 +455,7 @@
     "    \n",
     "    NAME = 'random_thermal_electrons'\n",
     "    STOCHASTIC_FIELD = True\n",
-    "    \n",
-    "    @property\n",
-    "    def field_checklist(self):\n",
-    "        return {'mean' : None, \n",
-    "                'std' : None}\n",
+    "    PARAMETERS_LIST = ['mean', 'std']\n",
     "    \n",
     "    def compute_field(self, seed):        \n",
     "        # Converts dimensional parameters into numerical values\n",
@@ -488,6 +474,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The `STOCHASTIC_FIELD` class-attribute tells whether the field is deterministic (i.e. the output depends only on the parameter values) or stochastic (i.e. the ouput is a random realisation which depends on a particular random seed). If this is absent, IMAGINE assumes the field is deterministic.\n",
+    "\n",
     "In the example above, the field at each point of the grid is drawn from a Gaussian distribution described by the parameters 'mean' and 'std', and the `seed` argument is used to initialize the random number generator.\n",
     "\n"
    ]
@@ -609,7 +597,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<!-- Before we exemplified two field types: 'magnetic_field' and 'thermal_electron_density'.  -->\n",
     "Before moving on, there is one specialised field type which is worth mentioning: the **dummy** field. \n",
     "\n",
     "Dummy fields are used when one wants to send  (varying) parameters *directly* \n",
@@ -624,8 +611,8 @@
     "contains built-in parametrised fields which one is willing to make use of. \n",
     "Dummy fields allow one to vary those parameters easily.\n",
     "\n",
-    "Below a simple example of how to define and initialize a dummy field (note that neither a `get_field` method nor \n",
-    "`stochastic_field` property are provided for a dummy field)."
+    "Below a simple example of how to define and initialize a dummy field (note that for dummy fields we do **not** specify `compute_field`,  \n",
+    "`STOCHASTIC_FIELD` or `PARAMETERS_LIST`)."
    ]
   },
   {
@@ -638,14 +625,25 @@
     "    \n",
     "class exampleDummy(DummyField):\n",
     "    NAME = 'example_dummy'\n",
-    "    \n",
-    "    @property\n",
-    "    def field_checklist(self):\n",
-    "        return {'A': None, 'B': 'foo', 'C': 'bar'}    \n",
-    "    @property\n",
-    "    def simulator_controllist(self):\n",
-    "        return {'lookup_directory': '/dummy/example', \n",
-    "                'choice_of_settings': ['tutorial','field']}    "
+    "    FIELD_CHECKLIST = {'A': None, 'B': 'foo', 'C': 'bar'}    \n",
+    "    SIMULATOR_CONTROLLIST = {'lookup_directory': '/dummy/example', \n",
+    "                             'choice_of_settings': ['tutorial','field']}    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Thus, instead of a `PARAMETERS_LIST`, one needs to specify a `FIELD_CHECKLIST` which contains a dictionary with parameter names as keys. \n",
+    "Its main use is to send to the Simulator *fixed settings* associated with a *particular \n",
+    "parameter*. For example, the `FIELD_CHECKLIST` is used by the Hammurabi-compatible\n",
+    "dummy fields to inform the Simulator class where in Hammurabi XML file the parameter value\n",
+    "should be saved.\n",
+    "\n",
+    "The extra `SIMULATOR_CONTROLLIST` attribute plays a \n",
+    "similar role: it is used to send settings associated with a field which \n",
+    "*are not associated with individual model parameters* to the Simulator. \n",
+    "A typical use is the setup of global switches which enable specific builtin field in "
    ]
   },
   {
@@ -692,20 +690,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Thus, instead of actual data arrays, the `get_data` of a dummy field returns a copy of its parameters dictionary, \n",
-    "supplemented by a random seed which can optionally be used by the Simulator to generate stochastic fields internally.\n",
-    "\n",
-    "In the context of dummy fields, the `field_checklist` property particularly important. \n",
-    "Its main use is to send to the Simulator *fixed settings* associated with a *particular \n",
-    "parameter*. For example, the field_checklist property is used by the Hammurabi-compatible\n",
-    "dummy fields to inform the Simulator class where in Hammurabi XML file the parameter value\n",
-    "should be saved.\n",
-    "\n",
-    "The extra `simulator_controllist` property (which is only present in dummy fields)  plays a \n",
-    "similar role: it is used to send settings associated with a field which \n",
-    "*are not associated with individual model parameters* to the Simulator. \n",
-    "A typical use is the setup of global switches which enable specific builtin field in \n",
-    "the Simulator."
+    "Therefore, instead of actual data arrays, the `get_data` of a dummy field returns a copy of its parameters dictionary, \n",
+    "supplemented by a random seed which can optionally be used by the Simulator to generate stochastic fields internally."
    ]
   },
   {
@@ -771,9 +757,9 @@
        " {'Bx': <Quantity [-30.,  30.] uG>,\n",
        "  'By': <Quantity [-30.,  30.] uG>,\n",
        "  'Bz': <Quantity [-10.,  10.] uG>},\n",
-       " {'Bx': <imagine.priors.basic_priors.FlatPrior at 0x7f43e85bbe10>,\n",
-       "  'By': <imagine.priors.basic_priors.FlatPrior at 0x7f43e85bb7d0>,\n",
-       "  'Bz': <imagine.priors.basic_priors.FlatPrior at 0x7f43e8097450>})"
+       " {'Bx': <imagine.priors.basic_priors.FlatPrior at 0x7f067daeda10>,\n",
+       "  'By': <imagine.priors.basic_priors.FlatPrior at 0x7f067daed350>,\n",
+       "  'Bz': <imagine.priors.basic_priors.FlatPrior at 0x7f067daedfd0>})"
       ]
      },
      "execution_count": 21,
@@ -921,9 +907,9 @@
     {
      "data": {
       "text/plain": [
-       "{'Bx': <imagine.priors.basic_priors.GaussianPrior at 0x7f43e803ec10>,\n",
-       " 'By': <imagine.priors.basic_priors.GaussianPrior at 0x7f43e803ef10>,\n",
-       " 'Bz': <imagine.priors.basic_priors.FlatPrior at 0x7f43e80401d0>}"
+       "{'Bx': <imagine.priors.basic_priors.GaussianPrior at 0x7f067daed390>,\n",
+       " 'By': <imagine.priors.basic_priors.GaussianPrior at 0x7f067d8c8a90>,\n",
+       " 'Bz': <imagine.priors.basic_priors.FlatPrior at 0x7f067d8c8a50>}"
       ]
      },
      "execution_count": 26,
@@ -1025,10 +1011,7 @@
     "    # Class attributes\n",
     "    NAME = 'By_Beq'\n",
     "    DEPENDENCIES_LIST = ['thermal_electron_density']\n",
-    "    \n",
-    "    @property\n",
-    "    def field_checklist(self):\n",
-    "        return { 'v0' : None }\n",
+    "    PARAMETERS_LIST = ['v0']\n",
     "\n",
     "    def compute_field(self, seed):\n",
     "        # Gets the thermal electron number density from another Field\n",
@@ -1127,10 +1110,7 @@
    "source": [
     "class ConstantElectrons(ThermalElectronDensityField):\n",
     "    NAME = 'constant_thermal_electron_density'\n",
-    "            \n",
-    "    @property\n",
-    "    def field_checklist(self):\n",
-    "        return {'A' : None}\n",
+    "    PARAMETERS_LIST = ['A']\n",
     "    \n",
     "    def compute_field(self, seed):\n",
     "        # \n",
@@ -1147,11 +1127,7 @@
     "    \"\"\"Example: constant magnetic field dependent on ConstantElectrons\"\"\"\n",
     "    NAME = 'constantBdep'\n",
     "    DEPENDENCIES_LIST = [ConstantElectrons]\n",
-    "    \n",
-    "    # NB field_checklist has been omitted since there are no parameters\n",
-    "    @property\n",
-    "    def field_checklist(self):\n",
-    "        return({})\n",
+    "    PARAMETERS_LIST = []\n",
     "\n",
     "    def compute_field(self, seed):\n",
     "        \n",

--- a/tutorials/tutorial_fields.ipynb
+++ b/tutorials/tutorial_fields.ipynb
@@ -182,7 +182,7 @@
     "    \"\"\"Example: thermal electron density of an (double) exponential disc\"\"\"\n",
     "    \n",
     "    NAME = 'exponential_disc_thermal_electrons'\n",
-    "    PARAMETERS_LIST = ['central_density', 'scale_radius', 'scale_height']\n",
+    "    PARAMETER_NAMES = ['central_density', 'scale_radius', 'scale_height']\n",
     "    \n",
     "    def compute_field(self, seed):\n",
     "        R = self.grid.r_cylindrical\n",
@@ -202,7 +202,7 @@
     "\n",
     "The class-attribute `NAME` allows one to keep track of which model we have used to generate our field. \n",
     "\n",
-    "The `PARAMETERS_LIST` attribute must contain all the required parameters for this particular kind of field.\n",
+    "The `PARAMETER_NAMES` attribute must contain all the required parameters for this particular kind of field.\n",
     "\n",
     "The function `compute_field` is what actually computes the density field. Note that it can access an associated grid object, which is stored in the `grid` attribute, and a dictionary of parameters, stored in the `parameters` attribute. The `compute_field` method takes a `seed` argument, which can is only used for stochastic fields (see later).\n",
     "\n",
@@ -325,7 +325,7 @@
     "class ConstantMagneticField(MagneticField):\n",
     "    \"\"\"Example: constant magnetic field\"\"\"\n",
     "    NAME = 'constantB'\n",
-    "    PARAMETERS_LIST = ['Bx', 'By', 'Bz']\n",
+    "    PARAMETER_NAMES = ['Bx', 'By', 'Bz']\n",
     "    \n",
     "    def compute_field(self, seed):\n",
     "        # Creates an empty array to store the result\n",
@@ -455,7 +455,7 @@
     "    \n",
     "    NAME = 'random_thermal_electrons'\n",
     "    STOCHASTIC_FIELD = True\n",
-    "    PARAMETERS_LIST = ['mean', 'std']\n",
+    "    PARAMETER_NAMES = ['mean', 'std']\n",
     "    \n",
     "    def compute_field(self, seed):        \n",
     "        # Converts dimensional parameters into numerical values\n",
@@ -612,7 +612,7 @@
     "Dummy fields allow one to vary those parameters easily.\n",
     "\n",
     "Below a simple example of how to define and initialize a dummy field (note that for dummy fields we do **not** specify `compute_field`,  \n",
-    "`STOCHASTIC_FIELD` or `PARAMETERS_LIST`)."
+    "`STOCHASTIC_FIELD` or `PARAMETER_NAMES`)."
    ]
   },
   {
@@ -634,7 +634,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Thus, instead of a `PARAMETERS_LIST`, one needs to specify a `FIELD_CHECKLIST` which contains a dictionary with parameter names as keys. \n",
+    "Thus, instead of a `PARAMETER_NAMES`, one needs to specify a `FIELD_CHECKLIST` which contains a dictionary with parameter names as keys. \n",
     "Its main use is to send to the Simulator *fixed settings* associated with a *particular \n",
     "parameter*. For example, the `FIELD_CHECKLIST` is used by the Hammurabi-compatible\n",
     "dummy fields to inform the Simulator class where in Hammurabi XML file the parameter value\n",
@@ -757,9 +757,9 @@
        " {'Bx': <Quantity [-30.,  30.] uG>,\n",
        "  'By': <Quantity [-30.,  30.] uG>,\n",
        "  'Bz': <Quantity [-10.,  10.] uG>},\n",
-       " {'Bx': <imagine.priors.basic_priors.FlatPrior at 0x7f067daeda10>,\n",
-       "  'By': <imagine.priors.basic_priors.FlatPrior at 0x7f067daed350>,\n",
-       "  'Bz': <imagine.priors.basic_priors.FlatPrior at 0x7f067daedfd0>})"
+       " {'Bx': <imagine.priors.basic_priors.FlatPrior at 0x7f6dec29c190>,\n",
+       "  'By': <imagine.priors.basic_priors.FlatPrior at 0x7f6dec3b6a90>,\n",
+       "  'Bz': <imagine.priors.basic_priors.FlatPrior at 0x7f6de4d2b0d0>})"
       ]
      },
      "execution_count": 21,
@@ -907,9 +907,9 @@
     {
      "data": {
       "text/plain": [
-       "{'Bx': <imagine.priors.basic_priors.GaussianPrior at 0x7f067daed390>,\n",
-       " 'By': <imagine.priors.basic_priors.GaussianPrior at 0x7f067d8c8a90>,\n",
-       " 'Bz': <imagine.priors.basic_priors.FlatPrior at 0x7f067d8c8a50>}"
+       "{'Bx': <imagine.priors.basic_priors.GaussianPrior at 0x7f6de4d23d10>,\n",
+       " 'By': <imagine.priors.basic_priors.GaussianPrior at 0x7f6de4b04950>,\n",
+       " 'Bz': <imagine.priors.basic_priors.FlatPrior at 0x7f6de4b04a50>}"
       ]
      },
      "execution_count": 26,
@@ -1011,7 +1011,7 @@
     "    # Class attributes\n",
     "    NAME = 'By_Beq'\n",
     "    DEPENDENCIES_LIST = ['thermal_electron_density']\n",
-    "    PARAMETERS_LIST = ['v0']\n",
+    "    PARAMETER_NAMES = ['v0']\n",
     "\n",
     "    def compute_field(self, seed):\n",
     "        # Gets the thermal electron number density from another Field\n",
@@ -1110,7 +1110,7 @@
    "source": [
     "class ConstantElectrons(ThermalElectronDensityField):\n",
     "    NAME = 'constant_thermal_electron_density'\n",
-    "    PARAMETERS_LIST = ['A']\n",
+    "    PARAMETER_NAMES = ['A']\n",
     "    \n",
     "    def compute_field(self, seed):\n",
     "        # \n",
@@ -1127,7 +1127,7 @@
     "    \"\"\"Example: constant magnetic field dependent on ConstantElectrons\"\"\"\n",
     "    NAME = 'constantBdep'\n",
     "    DEPENDENCIES_LIST = [ConstantElectrons]\n",
-    "    PARAMETERS_LIST = []\n",
+    "    PARAMETER_NAMES = []\n",
     "\n",
     "    def compute_field(self, seed):\n",
     "        \n",


### PR DESCRIPTION
Previously, all the fields required a property  `field_checklist` to be set. However, in practice, this was always a dictionary with names as keys and `None` as values, except in the case of dummy fields. This PR adjusts this, introducing the more intuitive ~`parameters_list`~ `parameter_names` property (which may be set through the ~`PARAMETERS_LIST`~ `PARAMETER_NAMES` class attribute) for non-dummy fields.

Dummy fields still use field_checklists and the previously written dummy fields should be backwards compatible (as the properties `field_checklists` and `simulator_controllist` still exist).