### PR TITLE
Sparse matrices for covariance

### DIFF
--- a/imagine/observables/observable.py
+++ b/imagine/observables/observable.py
@@ -32,6 +32,7 @@ import logging as log
 # Package imports
 import astropy.units as u
 import numpy as np
+from scipy.sparse import spmatrix
 
 # IMAGINE imports
 from imagine.tools import pmean, pshape, prosecutor, pglobal
@@ -53,15 +54,15 @@ class Observable(object):
     dtype : str
         Data type, must be either: 'measured', 'simulated' or 'covariance'
     """
-    def __init__(self, data=None, dtype=None, coords=None):
+    def __init__(self, data=None, dtype=None, coords=None, unit=None):
         self.dtype = dtype
 
         if isinstance(data, u.Quantity):
             self.data = data.value
             self.unit = data.unit
-        elif isinstance(data, np.ndarray):
+        elif isinstance(data, np.ndarray) or isinstance(data, spmatrix):
             self.data = data
-            self.unit = None
+            self.unit = unit
         else:
             raise ValueError
 
@@ -137,10 +138,10 @@ class Observable(object):
             self._data = None
         else:
             assert (len(data.shape) == 2)
-            assert isinstance(data, np.ndarray)
+            assert isinstance(data, np.ndarray) or isinstance(data, spmatrix)
             if (self._dtype == 'measured'):  # copy single-row data from memory
                 assert (data.shape[0] == 1)
-            self._data = np.copy(data)
+            self._data = data
             if (self._dtype == 'covariance'):
                 assert np.equal(*self.shape)
 

--- a/imagine/tools/__init__.py
+++ b/imagine/tools/__init__.py
@@ -23,7 +23,7 @@ from .visualization import *
 
 # All declaration
 __all__ = ['carrier_mapper', 'class_tools', 'config', 'covariance_estimator',
-           'io', 'masker', 'misc', 'mpi_helper', 'parallel_ops',
+           'io', 'masker', 'misc', 'mpi_helper', 'parallel_ops', 'sparse',
            'random_seed', 'timer']
 __all__.extend(carrier_mapper.__all__)
 __all__.extend(class_tools.__all__)

--- a/imagine/tools/config.py
+++ b/imagine/tools/config.py
@@ -53,7 +53,8 @@ rc = {'temp_dir': None,
       'distributed_arrays': False,
       'pipeline_default_seed': 1,
       'pipeline_distribute_ensemble': False,
-      'hammurabi_hamx_path': None}
+      'hammurabi_hamx_path': None,
+      'max_dense_matrix_size': 200}
 
 
 # %% FUNCTION DEFINITIONS

--- a/imagine/tools/parallel_ops.py
+++ b/imagine/tools/parallel_ops.py
@@ -9,9 +9,10 @@ or pure Python equivalents, depending on the contents of
 # Package imports
 from e13tools import add_to_all
 import numpy as np
+import scipy.sparse as spr
 
 # IMAGINE imports
-from imagine.tools import mpi_helper as m, rc
+from imagine.tools import mpi_helper as m, rc, sparse
 
 # All declaration
 __all__ = []
@@ -86,7 +87,10 @@ def ptrace(data):
     if rc['distributed_arrays']:
         return m.mpi_trace(data)
     else:
-        return np.trace(data)
+        # The following line is as fast as np.trace and is compatible
+        # sparse matrices
+        return test.diagonal().sum()
+
 
 
 @add_to_all
@@ -98,7 +102,41 @@ def peye(size):
     if rc['distributed_arrays']:
         return m.mpi_eye(size)
     else:
-        return np.eye(size)
+        if size < rc['max_dense_matrix_size']:
+            return np.eye(size)
+        else:
+            # Constructs a sparse matrix
+            return spr.eye(size).tocsc()
+
+@add_to_all
+def pdiag(elements, size=None):
+    """
+    Constructs a diagonal matrix.
+    If an array is provided, fills the diagonal with it.
+
+    Parameters
+    ----------
+    elements : numpy.ndarray or float
+        Fills the diagonal either with the float or the provided array
+    size : int
+        Size of the diagonal matrix
+    """
+    if len(elements)==1:
+        return peye * elements
+
+    if size is None:
+        size = len(elements)
+    else:
+        assert len(elements) == size
+
+    if rc['distributed_arrays']:
+        return elements * m.mpi_eye(size)
+    else:
+        if size < rc['max_dense_matrix_size']:
+            return elements * np.eye(size)
+        else:
+            # Constructs a sparse matrix
+            return spr.diags(elements,shape=(size,size))
 
 
 @add_to_all
@@ -125,9 +163,10 @@ def plu_solve(operator, source):
     """
     if rc['distributed_arrays']:
         return m.mpi_lu_solve(operator, source)
+    elif spr.issparse(operator) or spr.issparse(source):
+        return spr.linalg.spsolve(operator, source.T)
     else:
         return np.linalg.solve(operator, source.T)
-
 
 @add_to_all
 def pslogdet(data):
@@ -137,6 +176,8 @@ def pslogdet(data):
     """
     if rc['distributed_arrays']:
         return m.mpi_slogdet(data)
+    elif spr.issparse(data):
+        return sparse.slogdet(data)
     else:
         return np.linalg.slogdet(data)
 

--- a/imagine/tools/sparse.py
+++ b/imagine/tools/sparse.py
@@ -1,0 +1,62 @@
+"""
+Tools for working with sparse matrices
+"""
+# %% IMPORTS
+# Package imports
+import numpy as np
+import scipy.sparse as spr
+
+# All declaration
+__all__ = ['slogdet']
+
+# %% FUNCTION DEFINITIONS
+def minimumSwaps(arr):
+    """
+    Minimum number of swaps needed to order a
+    permutation array
+    """
+    # Based on
+    # https://www.thepoorcoder.com/hackerrank-minimum-swaps-2-solution/
+    a = dict(enumerate(arr))
+    b = {v:k for k,v in a.items()}
+    count = 0
+    for i in a:
+        x = a[i]
+        if x!=i:
+            y = b[i]
+            a[y] = x
+            b[x] = y
+            count+=1
+
+    return count
+
+
+def slogdet(arr):
+    """
+    Computes the sign and log of the determinant
+    of a sparse matrix
+
+    Parameters
+    ----------
+    arr : array_like
+        Sparse matrix (or numpy array)
+
+    Returns
+    -------
+    sign : int
+        Sign of the determinant
+    logdet : float
+        Natural logarithm of the determinant
+    """
+    # Based on the discussion in https://stackoverflow.com/a/60982033/4862845
+    lu = spr.linalg.splu(arr)
+
+    diagL = lu.L.diagonal()
+    diagU = lu.U.diagonal()
+
+    logdet = np.log(np.abs(diagL)).sum() + np.log(np.abs(diagU)).sum()
+
+    sign = np.sign(diagL).prod()*np.sign(diagU).prod()
+    sign *= (-1)**(minimumSwaps(lu.perm_r))
+
+    return sign, logdet

--- a/tutorials/tutorial_datasets.ipynb
+++ b/tutorials/tutorial_datasets.ipynb
@@ -72,13 +72,14 @@
     "from imagine.observables import FaradayDepthHEALPixDataset\n",
     "import numpy as np\n",
     "from astropy import units as u\n",
+    "import healpy as hp\n",
     "\n",
     "# Adjusts the data to the right format\n",
     "fd_raw = raw_dataset[3].data.astype(np.float)\n",
     "sigma_fd_raw = raw_dataset[4].data.astype(np.float)\n",
-    "# Makes it small, to save memory\n",
-    "fd_raw = fd_raw[::256]\n",
-    "sigma_fd_raw = sigma_fd_raw[::256]\n",
+    "# Makes it smaller, to save memory\n",
+    "fd_raw = hp.pixelfunc.ud_grade(fd_raw, 64)\n",
+    "sigma_fd_raw = hp.pixelfunc.ud_grade(sigma_fd_raw, 64)\n",
     "# We need to include units the data\n",
     "# (this avoids later errors and inconsistencies)\n",
     "fd_raw *= u.rad/u.m/u.m\n",
@@ -108,28 +109,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import requests, io\n",
-    "import numpy as np\n",
-    "from astropy.io import fits\n",
-    "from astropy import units as u\n",
     "from imagine.observables import FaradayDepthHEALPixDataset\n",
     "\n",
     "class FaradayDepthOppermann2012(FaradayDepthHEALPixDataset):\n",
-    "    def __init__(self, skip=None):\n",
+    "    def __init__(self, Nside=None):\n",
     "        # Fetches and reads the \n",
     "        download = requests.get('https://wwwmpa.mpa-garching.mpg.de/ift/faraday/2012/faraday.fits')\n",
     "        raw_dataset = fits.open(io.BytesIO(download.content))\n",
     "        # Adjusts the data to the right format\n",
     "        fd_raw = raw_dataset[3].data.astype(np.float)\n",
     "        sigma_fd_raw = raw_dataset[4].data.astype(np.float)\n",
+    "        # Reduces the resolution\n",
+    "        if Nside is not None:\n",
+    "            fd_raw = hp.pixelfunc.ud_grade(fd_raw, Nside)\n",
+    "            sigma_fd_raw = hp.pixelfunc.ud_grade(sigma_fd_raw, Nside)\n",
     "        # Includes units in the data\n",
     "        fd_raw *= u.rad/u.m/u.m\n",
     "        sigma_fd_raw *= u.rad/u.m/u.m\n",
-    "        \n",
-    "        # If requested, makes it small, to save memory in this example\n",
-    "        if skip is not None:\n",
-    "            fd_raw = fd_raw[::skip]\n",
-    "            sigma_fd_raw = sigma_fd_raw[::skip]\n",
     "        # Loads into the Dataset\n",
     "        super().__init__(data=fd_raw, error=sigma_fd_raw)"
    ]
@@ -147,7 +143,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dset = FaradayDepthOppermann2012(skip=256)"
+    "dset = FaradayDepthOppermann2012(Nside=64)"
    ]
   },
   {
@@ -199,7 +195,7 @@
      "data": {
       "text/html": [
        "<i>Table length=3</i>\n",
-       "<table id=\"table139726377436496\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<table id=\"table140276050629840\" class=\"table-striped table-bordered table-condensed\">\n",
        "<thead><tr><th>RAJ2000</th><th>DEJ2000</th><th>GLON</th><th>GLAT</th><th>RM</th><th>e_RM</th><th>PI</th><th>I</th><th>S5.2</th><th>f_S5.2</th><th>NVSS</th></tr></thead>\n",
        "<thead><tr><th>&quot;h:m:s&quot;</th><th>&quot;d:m:s&quot;</th><th>deg</th><th>deg</th><th>rad / m2</th><th>rad / m2</th><th>mJy</th><th>mJy</th><th></th><th></th><th></th></tr></thead>\n",
        "<thead><tr><th>bytes11</th><th>bytes11</th><th>float32</th><th>float32</th><th>int16</th><th>int16</th><th>float32</th><th>float64</th><th>bytes3</th><th>bytes1</th><th>bytes4</th></tr></thead>\n",
@@ -322,11 +318,11 @@
      "output_type": "stream",
      "text": [
       "Measurement keys:\n",
-      "\t ('fd', None, 8, None)\n",
+      "\t ('fd', None, 64, None)\n",
       "\t ('fd', None, 'tab', None)\n",
       "\n",
       "Covariance keys:\n",
-      "\t ('fd', None, 8, None)\n",
+      "\t ('fd', None, 64, None)\n",
       "\t ('fd', None, 'tab', None)\n"
      ]
     }
@@ -352,8 +348,15 @@
     "\n",
     "* If data is independent from frequency, data-freq is set `None`, otherwise it is the frequency in GHz.\n",
     "* The third value in the key-tuple is the HEALPix Nside (for maps) or the string 'tab' for tabular data. \n",
-    "* Finally, the last value, `ext` can be 'I','Q','U','PI','PA', None or other customized tags depending on the nature of the observable.\n",
-    "            \n",
+    "* Finally, the last value, `ext` can be 'I','Q','U','PI','PA', None or other customized tags depending on the nature of the observable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Manually including data\n",
+    "\n",
     "An alternative way to include data into an Observables dictionary is explicitly choosing the key and adjusting the data shape. One can see how this is handled by the Dataset object in the following cell"
    ]
   },
@@ -366,15 +369,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The key used in the \"name\" arg was: ('fd', None, 8, None)\n",
-      "The shape of data used in the \"new\" arg was: (1, 768)\n"
+      "The key used in the \"name\" arg was: ('fd', None, 64, None)\n",
+      "The shape of data used in the \"new\" arg was: (1, 49152)\n"
      ]
     }
    ],
    "source": [
     "# This is how HEALPix data can be included without the mediation of Datasets:\n",
     "mea.append(name=dset.key, data=dset.data)\n",
-    "cov.append(name=dset.key, data=dset.cov)\n",
+    "# The units of covariance matrices have to be provided separately\n",
+    "# (as sparse matrices to not support them)\n",
+    "cov.append(name=dset.key, data=dset.cov, unit=dset.cov_unit)\n",
     "# This is what Dataset is doing:\n",
     "print('The key used in the \"name\" arg was:', dset.key)\n",
     "print('The shape of data used in the \"new\" arg was:', dset.data.shape)"


### PR DESCRIPTION
Covariance matrices can get really large. In the simplest case, however, they are mostly diagonal and rather sparse. 
This PR implements the use of SciPy sparse matrices for IMAGINE covariances.