### PR TITLE
Changes to covariance and likelihood calculations

### DIFF
--- a/imagine/likelihoods/ensemble_likelihood.py
+++ b/imagine/likelihoods/ensemble_likelihood.py
@@ -44,12 +44,13 @@ class EnsembleLikelihood(Likelihood):
     use_trace_approximation : bool
         If True, the determinant of the combined covariance matrix is
         approximated using
-        :math:`\ln(|A+B)\approx \text{tr}\left[\ln\left(A+C\right)\right]`.
-        Otherwise, the determinant is calculated directly from the estimated
-        covariance matrix.
+        :math:`\ln(|A+B)\approx \text{tr}\left[\ln\left(A+C\right)\right]`
+        (NB this assumes that the observed data covariance is diagonal).
+        Otherwise (default), the determinant is calculated directly from the
+        covariance matrix from the simulations.
     """
     def __init__(self, measurement_dict, covariance_dict=None, mask_dict=None,
-                 cov_func=None, use_trace_approximation=True):
+                 cov_func=None, use_trace_approximation=False):
 
         super().__init__(measurement_dict, covariance_dict=covariance_dict,
                          mask_dict=mask_dict)

--- a/imagine/likelihoods/ensemble_likelihood.py
+++ b/imagine/likelihoods/ensemble_likelihood.py
@@ -69,17 +69,18 @@ class EnsembleLikelihood(Likelihood):
         assert  set(simulations_dict.keys()).issubset(self._measurement_dict.keys())
         assert  set(simulations_dict.keys()).issubset(self._covariance_dict.keys())
 
-        likelicache = 0
+        likelicache = 0.
         for name in simulations_dict.keys():
             # Estimated Galactic Covariance
             sim_mean, sim_cov = self.cov_func(simulations_dict[name].data)
-
+            # Observed data/covariance
             meas_data, meas_cov = (self._measurement_dict[name].data,
                                    self._covariance_dict[name].data)
-            diff = meas_data - sim_mean
 
+            diff = meas_data - sim_mean
             full_cov = meas_cov + sim_cov
             sign, logdet = pslogdet(full_cov*2.*np.pi)
+
             likelicache += -0.5*(np.vdot(diff, plu_solve(full_cov, diff)) + sign*logdet)
 
         return likelicache

--- a/imagine/likelihoods/ensemble_likelihood.py
+++ b/imagine/likelihoods/ensemble_likelihood.py
@@ -1,12 +1,5 @@
-"""
-ensemble likelihood, described in IMAGINE techincal report
-in principle
-it combines covariance matrices from both observations and simulations
-"""
-
 # %% IMPORTS
 # Built-in imports
-from copy import deepcopy
 import logging as log
 
 # Package imports
@@ -16,25 +9,38 @@ import numpy as np
 from imagine.likelihoods import Likelihood
 from imagine.observables.observable_dict import Simulations
 from imagine.tools.covariance_estimator import oas_mcov
-from imagine.tools.parallel_ops import pslogdet, plu_solve, ptrace
+from imagine.tools.parallel_ops import (pslogdet, plu_solve, ptrace, pdiag,
+                                        pvar, pmean)
 
 # All declaration
-__all__ = ['EnsembleLikelihood']
+__all__ = ['EnsembleLikelihood','EnsembleLikelihoodDiagonal']
 
 
 # %% CLASS DEFINITIONS
 class EnsembleLikelihood(Likelihood):
     """
-    EnsembleLikelihood class initialization function
+    Computes the likelihood accounting for the effects of stochastic fields
+
+    This is done by estimating the covariance associated the stochastic fields
+    from an ensemble of simulations.
 
     Parameters
     ----------
     measurement_dict : imagine.observables.observable_dict.Measurements
         Measurements
     covariance_dict : imagine.observables.observable_dict.Covariances
-        Covariances
+        The covariances associated with the measurements. If the keyword
+        argument is absent, the covariances will be read from the attribute
+        `measurement_dict.cov`.
     mask_dict : imagine.observables.observable_dict.Masks
-        Masks
+        Masks which will be applied to the Measurements, Covariances and
+        Simulations, before computing the likelihood
+    cov_func : func
+        A function which takes a (Nens, Ndata) data array (potentially
+        MPI distributed) and returns a tuple comprising the mean and an
+        estimated covariance matrix.
+        If absent, :py:func:`imagine.tools.covariance_estimator.oas_mcov` will
+        be used.
     """
     def __init__(self, measurement_dict, covariance_dict=None, mask_dict=None,
                  cov_func=None):
@@ -49,6 +55,7 @@ class EnsembleLikelihood(Likelihood):
             self.cov_func = oas_mcov
         else:
             self.cov_func = cov_func
+
 
     def call(self, simulations_dict):
         """
@@ -86,3 +93,67 @@ class EnsembleLikelihood(Likelihood):
         return likelicache
 
 
+class EnsembleLikelihoodDiagonal(Likelihood):
+    """
+    As `EnsembleLikelihood` but assuming that the covariance matrix is
+    diagonal and well described by the sample variance. Likewise, only
+    considers the diagonal of the observational covariance matrix.
+
+    Parameters
+    ----------
+    measurement_dict : imagine.observables.observable_dict.Measurements
+        Measurements
+    covariance_dict : imagine.observables.observable_dict.Covariances
+        The covariances associated with the measurements. If the keyword
+        argument is absent, the covariances will be read from the attribute
+        `measurement_dict.cov`.
+    mask_dict : imagine.observables.observable_dict.Masks
+        Masks which will be applied to the Measurements, Covariances and
+        Simulations, before computing the likelihood
+    """
+    def __init__(self, measurement_dict, covariance_dict=None, mask_dict=None):
+
+        super().__init__(measurement_dict, covariance_dict=covariance_dict,
+                         mask_dict=mask_dict)
+
+        # Requires covariaces to be present when using this type of Likelihood
+        assert self._covariance_dict is not None
+
+
+    def call(self, simulations_dict):
+        """
+        EnsembleLikelihood class call function
+
+        Parameters
+        ----------
+        simulations_dict : imagine.observables.observable_dict.Simulations
+            Simulations object
+
+        Returns
+        ------
+        likelicache : float
+            log-likelihood value (copied to all nodes)
+        """
+        log.debug('@ ensemble_likelihood::__call__')
+        assert isinstance(simulations_dict, Simulations)
+        assert  set(simulations_dict.keys()).issubset(self._measurement_dict.keys())
+        assert  set(simulations_dict.keys()).issubset(self._covariance_dict.keys())
+
+        likelicache = 0.
+        for name in simulations_dict.keys():
+            # Estimated Galactic Covariance
+            sim_mean = pmean(simulations_dict[name].data)
+            sim_var = pvar(simulations_dict[name].data)
+            # Observed data/covariance
+            meas_data = self._measurement_dict[name].data
+            meas_var =  pdiag(self._covariance_dict[name].data)
+
+            diff = meas_data - sim_mean
+            full_var = meas_var + sim_var
+
+            sign = np.sign(full_var).prod()
+            logdet = np.log(full_var*2.*np.pi).sum()
+
+            likelicache += -0.5*(np.vdot(diff, 1./full_var * diff) + sign*logdet)
+
+        return likelicache

--- a/imagine/likelihoods/ensemble_likelihood.py
+++ b/imagine/likelihoods/ensemble_likelihood.py
@@ -97,7 +97,7 @@ class EnsembleLikelihood(Likelihood):
             if not self.use_trace_approximation:
                 sign, logdet = pslogdet(full_cov*2.*np.pi)
             else:
-                diag_sum = meas_data.diagonal() + simulations_dict[name].data.var(axis=0)
+                diag_sum = meas_cov.diagonal() + simulations_dict[name].data.var(axis=0)
                 sign, logdet = 1, (np.log(diag_sum*2.*np.pi)).sum()
 
             likelicache += -0.5*(np.vdot(diff, plu_solve(full_cov, diff)) + sign*logdet)

--- a/imagine/tests/test_likelihood.py
+++ b/imagine/tests/test_likelihood.py
@@ -36,13 +36,13 @@ class TestSimpleLikeli(object):
         # no covariance
         lh = SimpleLikelihood(meadict)
         # calc by likelihood
-        rslt = lh(simdict)  # feed variable value, not parameter value
+        result = lh(simdict)  # feed variable value, not parameter value
         # calc by hand
         full_b = np.vstack(comm.allgather(arr_b))  # global arr_b
         diff = (np.mean(full_b, axis=0) - arr_a)
         baseline = -float(0.5)*float(np.vdot(diff, diff))
         # comapre
-        assert np.allclose(rslt, baseline)
+        assert np.allclose(result, baseline)
 
     def test_with_cov(self):
         simdict = Simulations()
@@ -67,18 +67,18 @@ class TestSimpleLikeli(object):
         # with covariance
         lh = SimpleLikelihood(meadict, covdict)
         # calc by likelihood
-        rslt = lh(simdict)  # feed variable value, not parameter value
+        result = lh(simdict)  # feed variable value, not parameter value
         # calc by hand
         full_b = np.vstack(comm.allgather(arr_b))  # global arr_b
         diff = (np.mean(full_b, axis=0) - arr_a)
         full_cov = np.vstack(comm.allgather(arr_c))  # global covariance
         (sign, logdet) = np.linalg.slogdet(full_cov*2.*np.pi)
         baseline = -0.5*(np.vdot(diff, np.linalg.solve(full_cov, diff.T))+sign*logdet)
-        assert np.allclose(rslt, baseline)
+        assert np.allclose(result, baseline)
 
 
 class TestEnsembleLikeli(object):
-    def test_without_simcov(self):
+    def test(self):
         simdict = Simulations()
         meadict = Measurements()
         covdict = Covariances()
@@ -102,13 +102,51 @@ class TestEnsembleLikeli(object):
         sim = Observable(arr_ens, 'simulated')
         simdict.append(name=('test', None, 4*mpisize, None),
                        data=sim, otype='plain')
+
         # simplelikelihood
         lh_simple = SimpleLikelihood(meadict, covdict)
-        rslt_simple = lh_simple(simdict)
+        result_simple = lh_simple(simdict)
         # ensemblelikelihood
-        lh_ensemble = EnsembleLikelihood(meadict, covdict)
-        rslt_ensemble = lh_ensemble(simdict)
-        assert rslt_ensemble == rslt_simple
+        lh_ensemble = EnsembleLikelihood(meadict, covdict,
+                                         use_trace_approximation=False)
+        result_ensemble = lh_ensemble(simdict)
+        assert result_ensemble == result_simple
+
+    def test_with_trace_approximation(self):
+        simdict = Simulations()
+        meadict = Measurements()
+        covdict = Covariances()
+        # mock measurements
+        arr_a = np.random.rand(1, 4*mpisize)
+        comm.Bcast(arr_a, root=0)
+        mea = Observable(arr_a, 'measured')
+        meadict.append(name=('test', None, 4*mpisize, None),
+                       data=mea, otype='plain')
+        # mock covariance (NB for the trace approximation to work, the data
+        # covariance needs to be diagonal)
+        arr_c = np.diag(np.random.rand(4))
+
+        cov = Observable(arr_c, 'covariance')
+        covdict.append(name=('test', None, 4*mpisize, None),
+                       cov_data=cov)
+        # mock observable with repeated single realisation
+        arr_b = np.random.rand(1, 4*mpisize)
+        comm.Bcast(arr_b, root=0)
+        arr_ens = np.zeros((2, 4*mpisize))
+        for i in range(len(arr_ens)):
+            arr_ens[i] = arr_b
+        sim = Observable(arr_ens, 'simulated')
+        simdict.append(name=('test', None, 4*mpisize, None),
+                       data=sim, otype='plain')
+
+        # simplelikelihood
+        lh_simple = SimpleLikelihood(meadict, covdict)
+        result_simple = lh_simple(simdict)
+        # ensemblelikelihood
+        lh_ensemble = EnsembleLikelihood(meadict, covdict,
+                                         use_trace_approximation=True)
+        result_ensemble = lh_ensemble(simdict)
+        assert result_ensemble == result_simple
 
     def test_diag(self):
         simdict = Simulations()
@@ -135,6 +173,6 @@ class TestEnsembleLikeli(object):
         result_ens = lh_ens(simdict)
         # EnsembleLikelihoodDiagonal
         lh_diag = EnsembleLikelihoodDiagonal(meadict, covdict)
-        result_diag = lh_diag (simdict)
+        result_diag = lh_diag(simdict)
 
         assert np.allclose(result_diag, result_ens)

--- a/imagine/tests/test_likelihood.py
+++ b/imagine/tests/test_likelihood.py
@@ -108,31 +108,3 @@ class TestEnsembleLikeli(object):
         rslt_ensemble = lh_ensemble(simdict)
         assert rslt_ensemble == rslt_simple
 
-    def test_without_cov(self):
-        simdict = Simulations()
-        meadict = Measurements()
-        # mock measurements
-        arr_a = np.random.rand(1, 12*mpisize**2)
-        comm.Bcast(arr_a, root=0)
-        mea = Observable(arr_a, 'measured')
-        meadict.append(name=('test', None, mpisize, None),
-                       data=mea, otype='HEALPix')
-        # mock observable with repeated single realisation
-        arr_b = np.random.rand(1, 12*mpisize**2)
-        comm.Bcast(arr_b, root=0)
-        if not mpirank:
-            arr_ens = np.zeros((3, 12*mpisize**2))
-        else:
-            arr_ens = np.zeros((2, 12*mpisize**2))
-        for i in range(len(arr_ens)):
-            arr_ens[i] = arr_b
-        sim = Observable(arr_ens, 'simulated')
-        simdict.append(name=('test', None, mpisize, None),
-                       data=sim, otype='HEALPix')
-        # simplelikelihood
-        lh_simple = SimpleLikelihood(meadict)
-        rslt_simple = lh_simple(simdict)
-        # ensemblelikelihood
-        lh_ensemble = EnsembleLikelihood(meadict)
-        rslt_ensemble = lh_ensemble(simdict)
-        assert rslt_ensemble == rslt_simple

--- a/imagine/tests/test_tools.py
+++ b/imagine/tests/test_tools.py
@@ -10,7 +10,8 @@ from imagine import rc
 from imagine.tools import (
     empirical_cov, oas_cov, oas_mcov, mpi_mean, mpi_arrange, mpi_trans,
     mpi_mult, mpi_eye, mpi_trace, mpi_shape, mpi_lu_solve, mpi_slogdet,
-    mpi_global, mpi_local, mask_obs, mask_cov, seed_generator, config)
+    mpi_global, mpi_local, mask_obs, mask_cov, seed_generator, mpi_diag,
+    config)
 
 # Globals
 comm = MPI.COMM_WORLD
@@ -142,6 +143,13 @@ class TestTools(object):
         full_arr = np.vstack(comm.allgather(arr))
         true_trace = np.trace(full_arr)
         assert np.allclose(test_trace, true_trace)
+
+    def test_mpi_diag(self):
+        arr = np.random.rand(2,2*mpisize)
+        test_diag = mpi_diag(arr)
+        full_arr = np.vstack(comm.allgather(arr))
+        true_diag = full_arr.diagonal()
+        assert np.allclose(test_diag, true_diag)
 
     def test_empirical_cov(self):
         # mock observable ensemble with identical realizations

--- a/imagine/tools/covariance_estimator.py
+++ b/imagine/tools/covariance_estimator.py
@@ -56,14 +56,56 @@ def empirical_cov(data):
         each node takes part of the rows.
     """
     log.debug('@ covariance_estimator::empirical_cov')
+    _, cov = empirical_mcov(data)
+
+    return cov
+
+
+def empirical_mcov(data):
+    r"""
+    Empirical covariance estimator
+
+
+    Given some data matrix, :math:`D`, where rows are different samples
+    and columns different properties, the covariance can be
+    estimated from
+
+    .. math::
+           U_{ij} = D_{ij} -  \overline{D}_j\,,\;
+           \text{with}\; \overline{D}_j=\tfrac{1}{N} \sum_{i=1}^N D_{ij}
+
+    .. math::
+          \text{cov} = \tfrac{1}{N} U^T U
+
+
+
+    Notes
+    -----
+        While conceptually simple, this is usually not the
+        best option.
+
+    Parameters
+    ----------
+    data : numpy.ndarray
+        Ensemble of observables, in global shape (ensemble size, data size).
+
+    Returns
+    -------
+    cov : numpy.ndarray
+        Distributed (not copied) covariance matrix in global shape (data size, data size),
+        each node takes part of the rows.
+    """
+    log.debug('@ covariance_estimator::empirical_mcov')
     assert isinstance(data, np.ndarray)
     assert (len(data.shape) == 2)
     # Get ensemble size (i.e. the number of rows)
     ensemble_size, _ = pshape(data)
     # Calculates covariance
-    u = data - pmean(data)
+    mean = pmean(data)
+    u = data - mean
     cov = pmult(ptrans(u), u) / ensemble_size
-    return cov
+    return mean, cov
+
 
 def oas_cov(data):
     r"""

--- a/imagine/tools/mpi_helper.py
+++ b/imagine/tools/mpi_helper.py
@@ -276,6 +276,33 @@ def mpi_trace(data):
 
 
 @add_to_all
+def mpi_diag(data):
+    """
+    Gets the diagonal of a distributed matrix
+
+    Parameters
+    ----------
+    data : numpy.ndarray
+        Array of data distributed over different processes.
+
+    Returns
+    -------
+    result : numpy.ndarray
+        Diagonal
+    """
+    log.debug('@ mpi_helper::mpi_diag')
+    assert (len(data.shape) == 2)
+    assert isinstance(data, np.ndarray)
+
+    local_row_begin, local_row_end = mpi_arrange(data.shape[1])
+    local_diagonal = data[:, local_row_begin:local_row_end].diagonal()
+
+    diagonal = comm.allgather(local_diagonal)
+
+    return np.concatenate(diagonal)
+
+
+@add_to_all
 def mpi_eye(size):
     """
     Produces an eye matrix according of shape (size,size)

--- a/imagine/tools/parallel_ops.py
+++ b/imagine/tools/parallel_ops.py
@@ -88,6 +88,17 @@ def ptrace(data):
     else:
         return np.trace(data)
 
+@add_to_all
+def pdiag(data):
+    """
+    :py:func:`imagine.tools.mpi_helper.mpi_diag` or :py:func:`numpy.diagonal`
+    depending on :py:data:`imagine.rc['distributed_arrays']`.
+    """
+    if rc['distributed_arrays']:
+        return m.mpi_diag(data)
+    else:
+        return data.diagonal
+
 
 @add_to_all
 def peye(size):

--- a/imagine/tools/parallel_ops.py
+++ b/imagine/tools/parallel_ops.py
@@ -54,6 +54,19 @@ def pmean(data):
 
 
 @add_to_all
+def pvar(data):
+    """
+    :py:func:`imagine.tools.mpi_helper.mpi_var` or :py:func:`numpy.var`
+    depending on :py:data:`imagine.rc['distributed_arrays']`.
+    """
+    if rc['distributed_arrays']:
+        # This will be done later!
+        raise NotImplementedError
+    else:
+        return data.var(axis=0)
+
+
+@add_to_all
 def ptrans(data):
     """
     :py:func:`imagine.tools.mpi_helper.mpi_mean` or :py:meth:`numpy.ndarray.T`
@@ -97,7 +110,7 @@ def pdiag(data):
     if rc['distributed_arrays']:
         return m.mpi_diag(data)
     else:
-        return data.diagonal
+        return data.diagonal()
 
 
 @add_to_all


### PR DESCRIPTION
The idea is to add more flexibility to the covariance and likelihood calculations. 

 - [x] Allows user choice of covariance estimator in `Ensemble Likelihood`
 - [x] Implements a diagonal covariance estimator (for testing) and 
 - [x] Implements a diagonal covariance estimator as a  `EnsembleLikelihoodDiagonal` class
 -  ~Precision-matrix-based likelihood calculations (with user choice of precision matrix estimator)~